### PR TITLE
Exclude "@unstoppabledomains" from logging warning

### DIFF
--- a/packages/app/src/api.ts
+++ b/packages/app/src/api.ts
@@ -269,6 +269,12 @@ export function registerVersion(
   if (variant) {
     library += `-${variant}`;
   }
+
+  if (library.includes('@unstoppabledomains')) {
+    // we don't want to log warning for unstoppabledomains
+    return;
+  }
+
   const libraryMismatch = library.match(/\s|\//);
   const versionMismatch = version.match(/\s|\//);
   if (libraryMismatch || versionMismatch) {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/firebase-auth",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "The Firebase Authenticaton component of the Firebase JS SDK.",
   "author": "Firebase <firebase-support@google.com> (https://firebase.google.com/)",
   "main": "dist/node/index.js",


### PR DESCRIPTION
We decided to stop logging this warning:

![image](https://github.com/user-attachments/assets/6e507369-6348-498b-aadd-f0c9affefac0)
